### PR TITLE
express endpoint for setup-confirm

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -21,6 +21,13 @@ app.get('/signup', (req, res) => {
     //Nothing here yet, not even sure if we will need it.
 })
 
+app.get('/setup/confirm', cors(), async (req,res) => {
+    // More of a 'get confirmation data'
+    // Should also be a post request to send the final account data to the db (still obviously not configured)
+    //console.log("setup/confirm test")
+    res.json("hello!")
+})
+
 app.get('/single-stonk/:name', (req, res) => {
 
     var stonkName = req.params.name;


### PR DESCRIPTION
Added the basic endpoint for the final step of the confirm endpoint. Nothing much yet, but will heavily work alongside the database later since it is storing user data associated (probably) with its userid token.